### PR TITLE
Minor fix to display correct release in title of docs html

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     command_options={
         'build_sphinx': {
             'version': ('setup.py', VERSION),
+            'release': ('setup.py', VERSION),
         }
     }
 )


### PR DESCRIPTION
:guardsman: PR fixes the issue of thoth-station.ninja html pages title display `NA` as releases instead of release value.