### PR TITLE
Normalize link text for comparison to package name

### DIFF
--- a/thoth/python/source.py
+++ b/thoth/python/source.py
@@ -174,6 +174,9 @@ class Source:
                 #   https://www.python.org/dev/peps/pep-0503/
                 link_text = link_text[:-1]
 
+            # Normalize link_text for comparison below
+            link_text = self.normalize_package_name(link_text)
+
             if self.is_normalized_python_package_name(package_name) and package_name == link_text:
                 packages.add(package_name)
 


### PR DESCRIPTION
Currently, packages with capital characters are ignored by the Source object when getting packages from https://pypi.org/simple. For example, it won't find flask because the link text is Flask:

```
from thoth.python import Source

PYPI = Source(url="https://pypi.org/simple")
all_packages = list(PYPI.get_packages())

print('flask' in all_packages)
```
`False`

This PR simply normalizes the link text before comparing the two.