### PR TITLE
Remove setuptools from Pipenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ beautifulsoup4 = "==4.6.3"
 lxml = "*"
 pyelftools = "*"
 packaging = "*"
-setuptools = "*"
 toml = "*"
 aiohttp = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "643962c5df5ac9dc979deb2a1e9b19f6f60e7c2fa2dbbc0d6a6097ab1d307f1d"
+            "sha256": "d483305d4ab6dd18ec219236e70417062cabaeb73df95e3048bf77e5eefb7af0"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
As setuptools are part of "core Pipenv packages" installed into the created
virtualenvironment, Pipenv does not track it in Pipfile.lock. Stateting it in
Pipfile causes issues on Kebechet side which fails to update dependencies:

  kebechet.exception.InternalError: Failed to retrieve version information for dependency setuptools, (dev: False)