### PR TITLE
When checking if version exists when querying the DB the same package…

### DIFF
--- a/thoth/python/aiosource.py
+++ b/thoth/python/aiosource.py
@@ -260,6 +260,7 @@ class AIOSource(Source):
 
         return AsyncIterablePackages(packages)
 
+    @lru_cache(maxsize=64)
     async def get_package_versions(self, package_name: str) -> AsyncIterableVersions:
         """Get listing of versions available for the given package."""
         if not self.warehouse:


### PR DESCRIPTION
… often shows up consecutively