### PR TITLE
Register pytest markers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements.txt
+include pytest.ini

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    online: marks tests that require Internet access


### PR DESCRIPTION
## Related Issues and Dependencies

Remove warning related to markers not being properly registered.

## This introduces a breaking change

- [x] No

```
tests/test_aiosource.py:133
  /workspace/repo/tests/test_aiosource.py:133: PytestUnknownMarkWarning: Unknown pytest.mark.online - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.online
```