### PR TITLE
pre-releases do not need to be always stated in Pipfile

### DIFF
--- a/thoth/python/pipfile.py
+++ b/thoth/python/pipfile.py
@@ -326,7 +326,7 @@ class ThothPipfileSection:
     def from_dict(cls, dict_: Dict[str, Any]) -> "ThothPipfileSection":
         """Convert Thoth specific section in Pipfile to a dictionary representation."""
         dict_ = dict(dict_)
-        allow_prereleases = dict_.pop("allow_prereleases") or {}
+        allow_prereleases = dict_.pop("allow_prereleases", None) or {}
         disable_index_adjustment = dict_.pop("disable_index_adjustment", False)
 
         if dict_:


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #362

## This introduces a breaking change

- [x] No
