### PR TITLE
Make Optional type parameters optional with None default

### DIFF
--- a/thoth/python/aiosource.py
+++ b/thoth/python/aiosource.py
@@ -27,7 +27,7 @@ import aiohttp
 
 from bs4 import BeautifulSoup
 
-from .exceptions import NotFound
+from .exceptions import NotFoundError
 from .artifact import Artifact
 from .source import Source
 
@@ -141,7 +141,7 @@ class AIOSource(Source):
         async with aiohttp.ClientSession(raise_for_status=True) as session:
             async with session.get(url) as response:
                 if response.status == 404:
-                    raise NotFound(
+                    raise NotFoundError(
                         f"Package {package_name} in version {package_version} not "
                         f"found on warehouse {self.url} ({self.name})"
                     )
@@ -174,7 +174,7 @@ class AIOSource(Source):
         async with aiohttp.ClientSession(raise_for_status=True) as session:
             async with session.get(url) as response:
                 if response.status == 404:
-                    raise NotFound(f"Package {package_name} not found on warehouse {self.url} ({self.name})")
+                    raise NotFoundError(f"Package {package_name} not found on warehouse {self.url} ({self.name})")
 
                 return await response.json()
 
@@ -201,7 +201,9 @@ class AIOSource(Source):
         async with aiohttp.ClientSession(raise_for_status=True) as session:
             async with session.get(url) as response:
                 if response.status == 404:
-                    raise NotFound(f"Package {package_name} is not present on index {self.url} (index {self.name})")
+                    raise NotFoundError(
+                        f"Package {package_name} is not present on index {self.url} (index {self.name})"
+                    )
 
                 text = await response.text()
                 soup = BeautifulSoup(text, "lxml")

--- a/thoth/python/digests_fetcher.py
+++ b/thoth/python/digests_fetcher.py
@@ -21,7 +21,7 @@ import typing
 import logging
 
 from .source import Source
-from .exceptions import NotFound
+from .exceptions import NotFoundError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class PythonDigestsFetcher(DigestsFetcherBase):
         for source in self._sources:
             try:
                 report[source.url] = source.get_package_hashes(package_name, package_version)
-            except NotFound as exc:
+            except NotFoundError as exc:
                 _LOGGER.debug(
                     f"Package {package_name} in version {package_version} not "
                     f"found on index {source.name}: {str(exc)}"

--- a/thoth/python/exceptions.py
+++ b/thoth/python/exceptions.py
@@ -18,52 +18,52 @@
 """Exceptions used in the thoth-python package."""
 
 
-class ThothPythonException(Exception):
+class ThothPythonExceptionError(Exception):
     """A base class for thoth-python exceptions."""
 
 
-class DirectDependencyRemoval(ThothPythonException):
+class DirectDependencyRemovalError(ThothPythonExceptionError):
     """Raised if trying to remove direct dependency from application stack.
 
     Or there is no option to remove the given dependency from application stack.
     """
 
 
-class UnableLock(ThothPythonException):
+class UnableLockError(ThothPythonExceptionError):
     """Raised if trying to lock invalid application stack or resolution cannot be done."""
 
 
-class PipfileParseError(ThothPythonException):
+class PipfileParseError(ThothPythonExceptionError):
     """An exception raised on invalid Pipfile or Pipfile.lock."""
 
 
-class InternalError(ThothPythonException):
+class InternalError(ThothPythonExceptionError):
     """An exception raised on bugs in the code base."""
 
 
-class PackageVersionAlreadyPresentError(ThothPythonException):
+class PackageVersionAlreadyPresentError(ThothPythonExceptionError):
     """An exception raised when adding a package in specific version that is already present."""
 
 
-class SourceNotFoundError(ThothPythonException):
+class SourceNotFoundError(ThothPythonExceptionError):
     """An exception raise when the given package source is not found."""
 
 
-class ConstraintsError(ThothPythonException):
+class ConstraintsError(ThothPythonExceptionError):
     """An exception raised when an issue with constraints found."""
 
 
-class VersionIdentifierError(ThothPythonException):
+class VersionIdentifierError(ThothPythonExceptionError):
     """An exception raised if the given version identifier is not a semver identifier."""
 
 
-class UnsupportedConfiguration(ThothPythonException):
+class UnsupportedConfigurationError(ThothPythonExceptionError):
     """Raised on unsupported configuration options."""
 
 
-class NotFound(ThothPythonException):
+class NotFoundError(ThothPythonExceptionError):
     """Raised if the given artifact cannot be found."""
 
 
-class FileLoadError(ThothPythonException):
+class FileLoadError(ThothPythonExceptionError):
     """Raised when failed to open or parse a file."""

--- a/thoth/python/package_version.py
+++ b/thoth/python/package_version.py
@@ -27,7 +27,7 @@ from packaging.version import parse as parse_version
 from packaging.utils import canonicalize_name
 
 
-from .exceptions import UnsupportedConfiguration
+from .exceptions import UnsupportedConfigurationError
 from .exceptions import PipfileParseError
 from .exceptions import InternalError
 from .source import Source
@@ -436,17 +436,17 @@ class PackageVersion:
             package_version = entry
         else:
             if any(vcs in entry for vcs in ("git", "hg", "bzr", "svn")):
-                raise UnsupportedConfiguration(
+                raise UnsupportedConfigurationError(
                     f"Package {package_name!r} uses a version control system instead of package index: {entry}"
                 )
 
             if "editable" in entry:
-                raise UnsupportedConfiguration(
+                raise UnsupportedConfigurationError(
                     f"Package {package_name!r} is editable local project instead of a package from a package index"
                 )
 
             if "version" not in entry:
-                raise UnsupportedConfiguration(
+                raise UnsupportedConfigurationError(
                     f"Package {package_name!r} does not state any version range specifier: {entry}"
                 )
 

--- a/thoth/python/pipfile.py
+++ b/thoth/python/pipfile.py
@@ -539,7 +539,7 @@ class PipfileLock(_PipfileBase):
             return cls.from_string(pipfile_file.read(), pipfile)
 
     @classmethod
-    def from_string(cls, pipfile_content: str, pipfile: Optional[Pipfile]) -> "PipfileLock":  # type: ignore
+    def from_string(cls, pipfile_content: str, pipfile: Optional[Pipfile] = None) -> "PipfileLock":  # type: ignore
         """Parse Pipfile.lock from its string content."""
         _LOGGER.debug("Parsing Pipfile.lock JSON representation from string")
         try:
@@ -550,7 +550,7 @@ class PipfileLock(_PipfileBase):
         return cls.from_dict(parsed, pipfile)
 
     @classmethod
-    def from_dict(cls, dict_: dict, pipfile: Optional[Pipfile]) -> "PipfileLock":
+    def from_dict(cls, dict_: dict, pipfile: Optional[Pipfile] = None) -> "PipfileLock":
         """Construct PipfileLock class from a parsed JSON representation as stated in actual Pipfile.lock."""
         _LOGGER.debug("Parsing Pipfile.lock")
         meta = PipfileMeta.from_dict(dict_["_meta"])
@@ -561,7 +561,7 @@ class PipfileLock(_PipfileBase):
             pipfile=pipfile,
         )
 
-    def to_string(self, pipfile: Pipfile = None) -> str:
+    def to_string(self, pipfile: Optional[Pipfile] = None) -> str:
         """Convert the current state of PipfileLock to its Pipfile.lock file representation."""
         _LOGGER.debug("Converting Pipfile.lock to JSON")
         return json.dumps(self.to_dict(pipfile), sort_keys=True, indent=4) + "\n"

--- a/thoth/python/project.py
+++ b/thoth/python/project.py
@@ -35,8 +35,8 @@ from .digests_fetcher import DigestsFetcherBase
 from .digests_fetcher import PythonDigestsFetcher
 from .exceptions import FileLoadError
 from .exceptions import InternalError
-from .exceptions import NotFound
-from .exceptions import UnableLock
+from .exceptions import NotFoundError
+from .exceptions import UnableLockError
 from .helpers import parse_requirements
 from .package_version import PackageVersion
 from .pipfile import Pipfile
@@ -389,14 +389,14 @@ class Project:
                     try:
                         latest = index.get_latest_package_version(package_version.name)
                         found = True
-                    except NotFound:
+                    except NotFoundError:
                         continue
 
                     if package_version.semantic_version != latest:
                         result[package_version.name] = (package_version, latest)
 
                 if not found:
-                    raise NotFound(
+                    raise NotFoundError(
                         f"Package {package_version!r} was not found on any package index"
                         f"configured: {self.pipfile_lock.meta.to_dict()}"
                     )
@@ -415,7 +415,7 @@ class Project:
                 _LOGGER.exception(
                     "Unable to lock application stack (return code: %d):\n%s\n", exc.return_code, exc.stdout, exc.stderr
                 )
-                raise UnableLock("Failed to perform lock") from exc
+                raise UnableLockError("Failed to perform lock") from exc
 
             _LOGGER.debug("pipenv stdout:\n%s", result.stdout)
             _LOGGER.debug("pipenv stderr:\n%s", result.stderr)


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Some methods have Optional[Pipfile] but then fail because there is missing None as default:

```
    pipfile_lock_ = PipfileLock.from_dict(advise['requirement_lock'])
TypeError: from_dict() missing 1 required positional argument: 'pipfile'
```

## This introduces a breaking change

- [ ] Yes
- [x] No
