### PR TITLE
change sleep to 0 because it still gives up core

### DIFF
--- a/thoth/python/aiosource.py
+++ b/thoth/python/aiosource.py
@@ -58,7 +58,7 @@ class AsyncIterablePackages:
 
     async def fetch_data(self) -> Optional[str]:  # Ignore PyDocStyleBear
         """Fetch data."""
-        await asyncio.sleep(0.1)  # Other coros get to run
+        await asyncio.sleep(0)  # Other coros get to run
 
         if len(self.packages) == 0:
             return None
@@ -88,7 +88,7 @@ class AsyncIterableVersions:
 
     async def fetch_data(self) -> Optional[str]:  # Ignore PyDocStyleBear
         """Fetch data."""
-        await asyncio.sleep(0.1)  # Other coros get to run
+        await asyncio.sleep(0)  # Other coros get to run
 
         if len(self.versions) == 0:
             return None
@@ -118,7 +118,7 @@ class AsyncIterableArtifacts:
 
     async def fetch_data(self) -> Optional[Tuple]:  # Ignore PyDocStyleBear
         """Fetch data."""
-        await asyncio.sleep(0.1)  # Other coros get to run
+        await asyncio.sleep(0)  # Other coros get to run
 
         if len(self.artifacts) == 0:
             return None


### PR DESCRIPTION
`sleep(0)` still gives up core control.  This matters for iterating over a single instance of the iterators, if you have 100 items to iterate and no other async threads it will result in 10 extra seconds of busy waiting.
