### PR TITLE
allow decode of characters

### DIFF
--- a/thoth/python/source.py
+++ b/thoth/python/source.py
@@ -21,6 +21,7 @@ import logging
 import re
 from functools import lru_cache
 from urllib.parse import urlparse
+from urllib.parse import unquote
 from datetime import datetime
 
 from typing import Optional, List, Union, Generator
@@ -231,6 +232,7 @@ class Source:
             )
 
         _LOGGER.debug(f"Parsed package version for package {package_name} from artifact {artifact_name}: {version}")
+
         return version
 
     def _simple_repository_list_versions(self, package_name: str) -> list:
@@ -323,6 +325,9 @@ class Source:
             artifact_url = link["href"]
             if not artifact_url.startswith(("http://", "https://")):
                 artifact_url = url + f"/{artifact_name}"
+
+            # Decode characters in link retrieved
+            artifact_name = unquote(artifact_name)
 
             artifacts.append((artifact_name, artifact_url))
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

This might be a workaround as the problem comes from the index on Torch. But feel free to close and adjust the change even in higher layers of the code.

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/python/issues/414 and returns correctly the versions:
```
0.2.0.post1
1.5.0+cpu
1.4.0+cpu
1.0.1
0.1.6.post20
1.3.0.post2
1.3.1
1.0.0
1.3.1+cpu
1.1.0.post2
```
