### PR TITLE
Strip any terminating slashes from index URL

### DIFF
--- a/thoth/python/source.py
+++ b/thoth/python/source.py
@@ -47,6 +47,7 @@ LEGACY_URLS = {"https://pypi.python.org/simple": "https://pypi.org/simple"}
 
 def normalize_url(url: str) -> str:
     """We normalize url to remove legacy urls."""
+    url = url.rstrip("/")
     if url in LEGACY_URLS:
         return LEGACY_URLS[url]
     return url


### PR DESCRIPTION
## Related Issues and Dependencies

In some cases, "https://pypi.org/simple/" is not equal to "https://pypi.org/simple" when doing index URL comparision. Let's strip `/`.

## This introduces a breaking change

- [x] No
