### PR TITLE
Overwrite supplied hash only if no hash was provided

### DIFF
--- a/thoth/python/pipfile.py
+++ b/thoth/python/pipfile.py
@@ -582,7 +582,9 @@ class PipfileLock(_PipfileBase):
         if not pipfile:
             raise InternalError("Pipfile has to be provided when generating Pipfile.lock to compute SHA hashes")
 
-        self.meta.set_hash(pipfile.hash())
+        if self.meta.hash is None:
+            self.meta.set_hash(pipfile.hash())
+
         self.sanitize_source_indexes()
 
         content = {


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/adviser/issues/2322

## This introduces a breaking change

- [x] No
