### PR TITLE
Enable TLS for Thoth

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -1,5 +1,5 @@
 host: khemenu.thoth-station.ninja
-tls_verify: false
+tls_verify: true
 requirements_format: pipenv
 
 runtime_environments:


### PR DESCRIPTION
## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

This is just to change the TLS verification setting in `.thoth.yaml` from `false` to `true`