### PR TITLE
Remove pipfile-requirements from thoth.yaml and updated OWNERS

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -11,7 +11,6 @@ runtime_environments:
     recommendation_type: latest
 
 managers:
-  - name: pipfile-requirements
   - name: thoth-advise
     configuration:
       labels: [bot]

--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ approvers:
   - codificat
   - kpostoffice
   - harshad16
-  - mayaCostantini
   - sesheta
   - sefkhet-abwy
 
@@ -13,8 +12,8 @@ reviewers:
   - codificat
   - kpostoffice
   - harshad16
-  - mayaCostantini
 
 emeritus_approvers:
-  - pacospace
-  - fridex
+  - pacospace # March 2022
+  - fridex # June 2022
+  - mayaCostantini # Jan 2023


### PR DESCRIPTION
Remove pipfile-requirements from thoth.yaml and updated OWNERS
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/python/pull/491
Fixes: https://github.com/thoth-station/python/pull/492

### Description

As we moved to Pipfile instead of requirements.txt , removing the `pipfile-requirement` manager from kebechet.
